### PR TITLE
feat: add settings packages as installable units

### DIFF
--- a/src/cli/commands/init.tsx
+++ b/src/cli/commands/init.tsx
@@ -1,6 +1,7 @@
 import { render, Box, useApp } from 'ink';
 import { useState, useCallback, useEffect } from 'react';
 import { writeManifest, readManifest } from '../../core/manifest.ts';
+import { writeSettingsManifest, readSettingsManifest } from '../../core/settings-manifest.ts';
 import { readConfig, writeConfig, KONSTRUCT_DIR } from '../../core/config.ts';
 import type { KonstructConfig } from '../../types/index.ts';
 import { basename } from 'node:path';
@@ -46,6 +47,18 @@ function InitApp({ options }: { options: InitOptions }) {
           cwd,
         );
         msgs.push({ variant: 'success', text: `Created ${scope} skills.json` });
+      }
+
+      // --- settings.json ---
+      const existingSettingsManifest = await readSettingsManifest(cwd);
+      if (existingSettingsManifest) {
+        msgs.push({ variant: 'warn', text: `${scope} settings.json already exists — skipping.` });
+      } else {
+        await writeSettingsManifest(
+          { name: basename(cwd), version: '1.0.0', settings: {} },
+          cwd,
+        );
+        msgs.push({ variant: 'success', text: `Created ${scope} settings.json` });
       }
 
       // --- konstruct.config.json ---

--- a/src/cli/commands/settings-add.tsx
+++ b/src/cli/commands/settings-add.tsx
@@ -1,0 +1,297 @@
+import { render, Box, useApp } from 'ink';
+import { useState, useCallback, useEffect } from 'react';
+import { parseSource } from '../../core/source-parser.ts';
+import { addSettingsToManifest, readSettingsManifest } from '../../core/settings-manifest.ts';
+import { installGitSettings, installUserSettings, discoverSettingsFromSource } from '../../core/settings-installer.ts';
+import { KONSTRUCT_DIR } from '../../core/config.ts';
+import { formatInstallTargets } from '../utils.ts';
+import { Banner } from '../components/Banner.tsx';
+import { StatusMessage } from '../components/StatusMessage.tsx';
+import { Spinner } from '../components/Spinner.tsx';
+import { Select } from '../components/Select.tsx';
+import { MultiSelect } from '../components/MultiSelect.tsx';
+import type { SkillSource, SettingsStrategy } from '../../types/index.ts';
+
+interface SettingsAddOptions {
+  global?: boolean;
+  user?: boolean;
+  path?: string;
+  ssh?: boolean;
+  settings?: string[];
+  strategy?: SettingsStrategy;
+}
+
+type Phase = 'parsing' | 'no-manifest' | 'discovering' | 'selecting' | 'installing' | 'done';
+
+function SettingsAddApp({ source, options: initialOptions }: { source: string; options: SettingsAddOptions }) {
+  const { exit } = useApp();
+  const [phase, setPhase] = useState<Phase>('parsing');
+  const [messages, setMessages] = useState<{ variant: 'success' | 'error' | 'info' | 'warn'; text: string }[]>([]);
+  const [spinnerLabel, setSpinnerLabel] = useState('');
+  const [settings, setSettings] = useState<{ name: string; description: string; repoPath: string; strategy?: string }[]>([]);
+  const [parsed, setParsed] = useState<SkillSource | null>(null);
+  const [options, setOptions] = useState(initialOptions);
+
+  useEffect(() => {
+    if (phase === 'done') exit();
+  }, [phase, exit]);
+
+  function finish() {
+    setSpinnerLabel('');
+    setPhase('done');
+  }
+
+  function addMsg(variant: 'success' | 'error' | 'info' | 'warn', text: string) {
+    setMessages((prev) => [...prev, { variant, text }]);
+  }
+
+  const [initialized, setInitialized] = useState(false);
+  if (!initialized) {
+    setInitialized(true);
+    (async () => {
+      let parsedSource: SkillSource;
+      try {
+        parsedSource = parseSource(source);
+      } catch (e) {
+        addMsg('error', e instanceof Error ? e.message : String(e));
+        finish();
+        return;
+      }
+      setParsed(parsedSource);
+
+      if (!options.global) {
+        const localManifest = await readSettingsManifest(process.cwd());
+        if (!localManifest) {
+          addMsg('warn', 'No settings.json found in the current directory.');
+          setPhase('no-manifest');
+          return;
+        }
+      }
+
+      await startInstall(parsedSource, options);
+    })();
+  }
+
+  const onNoManifestSelect = useCallback(async (index: number) => {
+    const opts = { ...options };
+    if (index === 0) {
+      opts.global = true;
+      setOptions(opts);
+    } else {
+      const { initCommand } = await import('./init.tsx');
+      await initCommand();
+    }
+    if (parsed) await startInstall(parsed, opts);
+  }, [options, parsed]);
+
+  async function startInstall(parsedSource: SkillSource, opts: SettingsAddOptions) {
+    if (parsedSource.type === 'file' || opts.user) {
+      if (opts.user && parsedSource.type !== 'file') {
+        addMsg('error', '--user flag requires a file: source (e.g. file:./my-settings)');
+        finish();
+        return;
+      }
+
+      const settingsName = deriveSettingsName(source, parsedSource);
+      setSpinnerLabel(`Adding "${settingsName}"…`);
+      setPhase('installing');
+
+      const result = await installUserSettings(parsedSource, settingsName, {
+        global: opts.global,
+        customPath: opts.path,
+        strategy: opts.strategy,
+      });
+
+      if (!result.success) {
+        addMsg('error', result.error ?? 'Unknown error');
+        finish();
+        return;
+      }
+
+      addMsg('success', `Added "${settingsName}" (strategy: ${result.strategy})`);
+      await addSettingsToManifest(settingsName, source, {
+        isUserSettings: true,
+        cwd: opts.global ? KONSTRUCT_DIR : undefined,
+        customPath: opts.path,
+        strategy: result.strategy !== 'copy' ? result.strategy : undefined,
+      });
+      addMsg('info', `Installed to: ${formatInstallTargets(result.paths, opts.path)}`);
+      addMsg('info', 'Added to settings.json');
+      finish();
+      return;
+    }
+
+    setSpinnerLabel('Cloning and discovering settings…');
+    setPhase('discovering');
+
+    let discovered: { name: string; description: string; repoPath: string; strategy?: string }[];
+    try {
+      discovered = await discoverSettingsFromSource(parsedSource, { ssh: opts.ssh });
+    } catch (e) {
+      addMsg('error', e instanceof Error ? e.message : String(e));
+      finish();
+      return;
+    }
+
+    addMsg('success', 'Discovery complete');
+
+    if (discovered.length === 0) {
+      addMsg('error', 'No SETTINGS.md files found in that repository.');
+      finish();
+      return;
+    }
+
+    if (opts.settings) {
+      const notFound = opts.settings.filter(s => !discovered.some(d => d.name === s));
+      if (notFound.length > 0) {
+        addMsg('error', `Settings not found: ${notFound.join(', ')}`);
+        setSpinnerLabel('');
+        setSettings(discovered);
+        setPhase('selecting');
+        return;
+      }
+      const picks = discovered.filter(d => opts.settings!.includes(d.name));
+      await installPicks(parsedSource, opts, picks, discovered);
+      return;
+    }
+
+    if (discovered.length === 1) {
+      addMsg('info', `Found 1 settings package: "${discovered[0]!.name}"`);
+      await installPicks(parsedSource, opts, [discovered[0]!], discovered);
+    } else {
+      setSpinnerLabel('');
+      setSettings(discovered);
+      setPhase('selecting');
+    }
+  }
+
+  const onSettingsConfirm = useCallback(async (indices: number[]) => {
+    if (indices.length === 0) {
+      addMsg('info', 'Nothing selected.');
+      finish();
+      return;
+    }
+    const picks = indices.map((i) => settings[i]!);
+    if (parsed) await installPicks(parsed, options, picks, settings);
+  }, [settings, parsed, options]);
+
+  async function installPicks(
+    parsedSource: SkillSource,
+    opts: SettingsAddOptions,
+    picks: { name: string; repoPath: string; strategy?: string }[],
+    allSettings: { name: string; repoPath: string }[],
+  ) {
+    setPhase('installing');
+    let installed = 0;
+
+    for (const chosen of picks) {
+      const persistedSource =
+        parsedSource.subpath || allSettings.length === 1
+          ? source
+          : serializeSource(parsedSource, chosen.repoPath);
+
+      const installSource: SkillSource = {
+        ...parsedSource,
+        subpath: chosen.repoPath || undefined,
+      };
+
+      const effectiveStrategy = opts.strategy
+        ?? (chosen.strategy as SettingsStrategy | undefined)
+        ?? 'copy';
+
+      setSpinnerLabel(`Installing "${chosen.name}"…`);
+      const result = await installGitSettings(installSource, chosen.name, {
+        global: opts.global,
+        customPath: opts.path,
+        ssh: opts.ssh,
+        strategy: effectiveStrategy,
+      });
+
+      if (!result.success) {
+        addMsg('error', result.error ?? 'Unknown error');
+        continue;
+      }
+
+      addMsg('success', `Installed "${chosen.name}" (strategy: ${result.strategy})`);
+      await addSettingsToManifest(chosen.name, persistedSource, {
+        cwd: opts.global ? KONSTRUCT_DIR : undefined,
+        customPath: opts.path,
+        strategy: result.strategy !== 'copy' ? result.strategy : undefined,
+      });
+      addMsg('info', `Installed to: ${formatInstallTargets(result.paths, opts.path)}`);
+      installed++;
+    }
+
+    addMsg('info', `${installed}/${picks.length} settings package(s) added to settings.json`);
+    finish();
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Banner />
+      {messages.map((m, i) => (
+        <StatusMessage key={i} variant={m.variant}>{m.text}</StatusMessage>
+      ))}
+      {phase === 'no-manifest' && (
+        <Select
+          prompt="How would you like to proceed?"
+          items={['Install globally (default agents)', 'Initialize this project and install here']}
+          onSelect={onNoManifestSelect}
+        />
+      )}
+      {phase === 'selecting' && settings.length > 0 && (
+        <MultiSelect
+          prompt="Select settings packages to install:"
+          items={settings.map((s) => s.name)}
+          onConfirm={onSettingsConfirm}
+        />
+      )}
+      {(phase === 'discovering' || phase === 'installing') && spinnerLabel && (
+        <Spinner label={spinnerLabel} />
+      )}
+    </Box>
+  );
+}
+
+function serializeSource(parsed: { type: string; url: string; ref?: string }, repoPath: string): string {
+  const ref = parsed.ref ? `#${parsed.ref}` : '';
+
+  if (parsed.type === 'github') {
+    const match = parsed.url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (match) return `github:${match[1]}/${match[2]}/${repoPath}${ref}`;
+  }
+
+  if (parsed.type === 'gitlab') {
+    const match = parsed.url.match(/gitlab\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (match) return `gitlab:${match[1]}/${match[2]}/${repoPath}${ref}`;
+  }
+
+  return `git:${parsed.url}${ref}`;
+}
+
+function deriveSettingsName(source: string, parsed: { subpath?: string; url: string }): string {
+  if (parsed.subpath) {
+    const segments = parsed.subpath.split('/').filter(Boolean);
+    if (segments.length > 0) return segments[segments.length - 1]!;
+  }
+
+  if (source.startsWith('file:')) {
+    const path = source.slice('file:'.length).replace(/\/+$/, '');
+    const segments = path.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? 'settings';
+  }
+
+  try {
+    const url = new URL(parsed.url);
+    const parts = url.pathname.split('/').filter(Boolean);
+    const repo = parts[parts.length - 1]?.replace(/\.git$/, '');
+    return repo ?? 'settings';
+  } catch {
+    return 'settings';
+  }
+}
+
+export async function settingsAddCommand(source: string, options: SettingsAddOptions) {
+  const { waitUntilExit } = render(<SettingsAddApp source={source} options={options} />);
+  await waitUntilExit();
+}

--- a/src/cli/commands/settings-install.tsx
+++ b/src/cli/commands/settings-install.tsx
@@ -1,0 +1,144 @@
+import { render, Text, Box, Static, useApp } from 'ink';
+import { useEffect, useState } from 'react';
+import { readSettingsManifest, parseSettingsEntry } from '../../core/settings-manifest.ts';
+import { parseSource } from '../../core/source-parser.ts';
+import { installGitSettings, installUserSettings } from '../../core/settings-installer.ts';
+import { formatInstallTargets } from '../utils.ts';
+import { StatusMessage } from '../components/StatusMessage.tsx';
+import { Spinner } from '../components/Spinner.tsx';
+
+interface SettingsInstallOptions {
+  global?: boolean;
+  ssh?: boolean;
+}
+
+interface CompletedSettings {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+function SettingsInstallApp({ options }: { options: SettingsInstallOptions }) {
+  const { exit } = useApp();
+  const [completed, setCompleted] = useState<CompletedSettings[]>([]);
+  const [current, setCurrent] = useState<string>();
+  const [total, setTotal] = useState(0);
+  const [fatalError, setFatalError] = useState<string>();
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (done) exit();
+  }, [done, exit]);
+
+  useEffect(() => {
+    (async () => {
+      const manifest = await readSettingsManifest();
+      if (!manifest) {
+        setFatalError('No settings.json found. Run "konstruct init" first.');
+        setDone(true);
+        return;
+      }
+
+      const gitEntries = Object.entries(manifest.settings);
+      const userEntries = Object.entries(manifest.userSettings ?? {});
+      const count = gitEntries.length + userEntries.length;
+      setTotal(count);
+
+      if (count === 0) {
+        setDone(true);
+        return;
+      }
+
+      for (const [name, entry] of gitEntries) {
+        setCurrent(name);
+        const { source, customPath, strategy } = parseSettingsEntry(entry);
+        const parsed = parseSource(source);
+        const result = await installGitSettings(parsed, name, {
+          global: options.global,
+          ssh: options.ssh,
+          customPath,
+          strategy,
+        });
+
+        setCompleted((prev) => [
+          ...prev,
+          {
+            name,
+            ok: result.success,
+            detail: result.success
+              ? `→ ${formatInstallTargets(result.paths, customPath)} (${result.strategy})`
+              : result.error ?? 'Unknown error',
+          },
+        ]);
+      }
+
+      for (const [name, entry] of userEntries) {
+        setCurrent(name);
+        const { source, customPath, strategy } = parseSettingsEntry(entry);
+        const parsed = parseSource(source);
+        const result = await installUserSettings(parsed, name, {
+          global: options.global,
+          customPath,
+          strategy,
+        });
+
+        setCompleted((prev) => [
+          ...prev,
+          {
+            name,
+            ok: result.success,
+            detail: result.success
+              ? `→ ${formatInstallTargets(result.paths, customPath)} (${result.strategy})`
+              : result.error ?? 'Unknown error',
+          },
+        ]);
+      }
+
+      setCurrent(undefined);
+      setDone(true);
+    })();
+  }, []);
+
+  if (fatalError) {
+    return <StatusMessage variant="error">{fatalError}</StatusMessage>;
+  }
+
+  if (total === 0 && done) {
+    return <StatusMessage variant="info">No settings in manifest. Use "konstruct settings add {'<source>'}" to add some.</StatusMessage>;
+  }
+
+  const failures = completed.filter((c) => !c.ok).length;
+
+  return (
+    <Box flexDirection="column">
+      {total > 0 && <StatusMessage variant="info">Installing {total} settings package(s)…</StatusMessage>}
+      <Static items={completed}>
+        {(item) => (
+          <Box key={item.name} flexDirection="column">
+            <StatusMessage variant={item.ok ? 'success' : 'error'}>{item.name}</StatusMessage>
+            {item.ok ? (
+              <Text>  <Text color="cyan">ℹ</Text> {item.detail}</Text>
+            ) : (
+              <Text>  <Text color="red">✗</Text> {item.detail}</Text>
+            )}
+          </Box>
+        )}
+      </Static>
+      {current && <Spinner label={current} />}
+      {done && (
+        <Box marginTop={1}>
+          {failures === 0 ? (
+            <StatusMessage variant="success">All {total} settings package(s) installed.</StatusMessage>
+          ) : (
+            <StatusMessage variant="error">{failures} of {total} settings package(s) failed.</StatusMessage>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export async function settingsInstallCommand(options: SettingsInstallOptions) {
+  const { waitUntilExit } = render(<SettingsInstallApp options={options} />);
+  await waitUntilExit();
+}

--- a/src/cli/commands/settings-list.tsx
+++ b/src/cli/commands/settings-list.tsx
@@ -1,0 +1,116 @@
+import { render, Text, Box } from 'ink';
+import { useEffect, useState } from 'react';
+import { readSettingsManifest } from '../../core/settings-manifest.ts';
+import { readConfig, getAgentSettingsDirs, KONSTRUCT_DIR } from '../../core/config.ts';
+import { discoverSettings } from '../../core/settings-discover.ts';
+import { StatusMessage } from '../components/StatusMessage.tsx';
+
+interface SettingsListOptions {
+  global?: boolean;
+}
+
+interface ListState {
+  installed: [string, unknown][];
+  user: [string, unknown][];
+  untracked: { name: string; path: string }[];
+  error?: string;
+  done: boolean;
+}
+
+function SettingsListApp({ options }: { options: SettingsListOptions }) {
+  const [state, setState] = useState<ListState>({
+    installed: [],
+    user: [],
+    untracked: [],
+    done: false,
+  });
+
+  useEffect(() => {
+    (async () => {
+      const isGlobal = options.global ?? false;
+
+      const manifest = await readSettingsManifest(isGlobal ? KONSTRUCT_DIR : undefined);
+      if (!manifest) {
+        setState((s) => ({ ...s, error: 'No settings.json found. Run "konstruct init" first.', done: true }));
+        return;
+      }
+
+      const config = await readConfig(process.cwd(), isGlobal);
+      const agents =
+        config && config.agents.length > 0
+          ? config.agents
+          : config?.global?.defaultAgents ?? ['claude'];
+      const dirs = getAgentSettingsDirs(agents, isGlobal);
+
+      const installedEntries = Object.entries(manifest.settings);
+      const userEntries = Object.entries(manifest.userSettings ?? {});
+      const manifestNames = new Set([
+        ...installedEntries.map(([name]) => name),
+        ...userEntries.map(([name]) => name),
+      ]);
+
+      const untracked: { name: string; path: string }[] = [];
+      for (const dir of dirs) {
+        const discovered = await discoverSettings(dir);
+        for (const pkg of discovered) {
+          if (!manifestNames.has(pkg.name) && !untracked.some((u) => u.name === pkg.name)) {
+            untracked.push({ name: pkg.name, path: pkg.path });
+          }
+        }
+      }
+
+      setState({
+        installed: installedEntries,
+        user: userEntries,
+        untracked,
+        done: true,
+      });
+    })();
+  }, []);
+
+  if (state.error) {
+    return <StatusMessage variant="error">{state.error}</StatusMessage>;
+  }
+
+  if (!state.done) return null;
+
+  const hasAnything = state.installed.length > 0 || state.user.length > 0 || state.untracked.length > 0;
+  if (!hasAnything) {
+    return <StatusMessage variant="info">No settings found. Use "konstruct settings add {'<source>'}" to add some.</StatusMessage>;
+  }
+
+  return (
+    <Box flexDirection="column">
+      {state.installed.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>Installed settings:</Text>
+          {state.installed.map(([name]) => (
+            <Text key={name}>  <Text color="cyan">{name}</Text></Text>
+          ))}
+        </Box>
+      )}
+      {state.user.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>User settings:</Text>
+          {state.user.map(([name]) => (
+            <Text key={name}>  <Text color="cyan">{name}</Text></Text>
+          ))}
+        </Box>
+      )}
+      {state.untracked.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>Untracked settings:</Text>
+          {state.untracked.map(({ name }) => (
+            <Text key={name}>  <Text color="cyan">{name}</Text></Text>
+          ))}
+        </Box>
+      )}
+      <Text>{''}</Text>
+    </Box>
+  );
+}
+
+export async function settingsListCommand(options: SettingsListOptions = {}) {
+  const { waitUntilExit } = render(<SettingsListApp options={options} />);
+  await waitUntilExit();
+}

--- a/src/cli/commands/settings-remove.tsx
+++ b/src/cli/commands/settings-remove.tsx
@@ -1,0 +1,115 @@
+import { render, Box, useApp } from 'ink';
+import { useEffect, useState } from 'react';
+import { removeSettingsFromManifest, readSettingsManifest } from '../../core/settings-manifest.ts';
+import { readConfig, getAgentSettingsDirs, KONSTRUCT_DIR } from '../../core/config.ts';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { exists } from '../../utils/fs.ts';
+import { StatusMessage } from '../components/StatusMessage.tsx';
+
+interface SettingsRemoveOptions {
+  global?: boolean;
+}
+
+interface SettingsStatus {
+  name: string;
+  status: 'success' | 'error' | 'warn';
+  message: string;
+}
+
+function SettingsRemoveApp({ names, options }: { names: string[]; options: SettingsRemoveOptions }) {
+  const { exit } = useApp();
+  const [results, setResults] = useState<SettingsStatus[]>([]);
+  const [done, setDone] = useState(false);
+  const [fatalError, setFatalError] = useState<string>();
+
+  useEffect(() => {
+    if (done) exit();
+  }, [done, exit]);
+
+  useEffect(() => {
+    (async () => {
+      const isGlobal = options.global ?? false;
+      const manifestCwd = isGlobal ? KONSTRUCT_DIR : undefined;
+      const manifest = await readSettingsManifest(manifestCwd);
+
+      if (!isGlobal && !manifest) {
+        setFatalError('No settings.json found.');
+        setDone(true);
+        return;
+      }
+
+      const config = await readConfig(process.cwd(), isGlobal);
+      const agents =
+        config && config.agents.length > 0
+          ? config.agents
+          : config?.global?.defaultAgents ?? ['claude'];
+      const dirs = getAgentSettingsDirs(agents, isGlobal);
+
+      const statuses: SettingsStatus[] = [];
+
+      for (const name of names) {
+        const entry = manifest
+          ? manifest.settings[name] ?? manifest.userSettings?.[name]
+          : undefined;
+        const inManifest = !!entry;
+
+        let onDisk = false;
+        if (isGlobal) {
+          for (const dir of dirs) {
+            if (await exists(join(dir, name))) { onDisk = true; break; }
+          }
+        }
+
+        if (!inManifest && !onDisk) {
+          statuses.push({
+            name,
+            status: 'error',
+            message: `Settings "${name}" not found${isGlobal ? ' in global settings directories' : ' in settings.json'}`,
+          });
+          continue;
+        }
+
+        // Warn about merge-mode settings that can't be auto-reversed
+        if (entry?.strategy === 'merge') {
+          statuses.push({
+            name,
+            status: 'warn',
+            message: `Settings "${name}" used merge strategy — merged values cannot be auto-reversed. Please manually edit your agent settings files if needed.`,
+          });
+        }
+
+        if (inManifest) await removeSettingsFromManifest(name, manifestCwd);
+
+        // Remove copied directories (copy/replace mode)
+        for (const dir of dirs) {
+          await rm(join(dir, name), { recursive: true, force: true }).catch(() => {});
+        }
+
+        statuses.push({ name, status: 'success', message: `Removed "${name}"` });
+      }
+
+      setResults(statuses);
+      setDone(true);
+    })();
+  }, []);
+
+  return (
+    <Box flexDirection="column">
+      {fatalError && <StatusMessage variant="error">{fatalError}</StatusMessage>}
+      {results.map((r) => (
+        <StatusMessage key={r.name} variant={r.status === 'error' ? 'error' : r.status === 'warn' ? 'warn' : 'success'}>{r.message}</StatusMessage>
+      ))}
+      {done && !fatalError && results.length > 1 && (
+        <StatusMessage variant="info">
+          {results.filter((r) => r.status === 'success').length}/{names.length} settings package(s) removed
+        </StatusMessage>
+      )}
+    </Box>
+  );
+}
+
+export async function settingsRemoveCommand(names: string[], options: SettingsRemoveOptions = {}) {
+  const { waitUntilExit } = render(<SettingsRemoveApp names={names} options={options} />);
+  await waitUntilExit();
+}

--- a/src/cli/commands/settings-update.tsx
+++ b/src/cli/commands/settings-update.tsx
@@ -1,0 +1,162 @@
+import { render, Text, Box, Static, useApp } from 'ink';
+import { useEffect, useState } from 'react';
+import { readSettingsManifest, parseSettingsEntry } from '../../core/settings-manifest.ts';
+import { parseSource } from '../../core/source-parser.ts';
+import { installGitSettings, checkSettingsForUpdates } from '../../core/settings-installer.ts';
+import { KONSTRUCT_DIR } from '../../core/config.ts';
+import { formatInstallTargets } from '../utils.ts';
+import { StatusMessage } from '../components/StatusMessage.tsx';
+import { Spinner } from '../components/Spinner.tsx';
+import { DiffView } from '../components/DiffView.tsx';
+
+interface SettingsUpdateOptions {
+  global?: boolean;
+  ssh?: boolean;
+}
+
+interface CompletedSettings {
+  name: string;
+  status: 'updated' | 'up-to-date' | 'installed' | 'failed';
+  detail?: string;
+  diff?: { added: string[]; changed: string[]; removed: string[] };
+}
+
+function SettingsUpdateApp({ options }: { options: SettingsUpdateOptions }) {
+  const { exit } = useApp();
+  const [completed, setCompleted] = useState<CompletedSettings[]>([]);
+  const [current, setCurrent] = useState<string>();
+  const [total, setTotal] = useState(0);
+  const [fatalError, setFatalError] = useState<string>();
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (done) exit();
+  }, [done, exit]);
+
+  useEffect(() => {
+    (async () => {
+      const manifest = await readSettingsManifest(options.global ? KONSTRUCT_DIR : undefined);
+      if (!manifest) {
+        setFatalError('No settings.json found. Run "konstruct init" first.');
+        setDone(true);
+        return;
+      }
+
+      const gitEntries = Object.entries(manifest.settings);
+      setTotal(gitEntries.length);
+
+      if (gitEntries.length === 0) {
+        setDone(true);
+        return;
+      }
+
+      for (const [name, entry] of gitEntries) {
+        setCurrent(`${name} — checking…`);
+        const { source, customPath, strategy } = parseSettingsEntry(entry);
+        const parsed = parseSource(source);
+
+        let diff;
+        try {
+          diff = await checkSettingsForUpdates(parsed, name, {
+            global: options.global,
+            ssh: options.ssh,
+            customPath,
+            strategy,
+          });
+        } catch (e) {
+          setCompleted((prev) => [
+            ...prev,
+            { name, status: 'failed', detail: e instanceof Error ? e.message : String(e) },
+          ]);
+          continue;
+        }
+
+        if (diff === null) {
+          setCurrent(`${name} — installing…`);
+          const result = await installGitSettings(parsed, name, {
+            global: options.global,
+            ssh: options.ssh,
+            customPath,
+            strategy,
+          });
+          setCompleted((prev) => [
+            ...prev,
+            result.success
+              ? { name, status: 'installed', detail: `installed → ${formatInstallTargets(result.paths, customPath)}` }
+              : { name, status: 'failed', detail: result.error },
+          ]);
+          continue;
+        }
+
+        if (diff.upToDate) {
+          setCompleted((prev) => [...prev, { name, status: 'up-to-date' }]);
+          continue;
+        }
+
+        setCurrent(`${name} — updating…`);
+        const result = await installGitSettings(parsed, name, {
+          global: options.global,
+          ssh: options.ssh,
+          customPath,
+          strategy,
+        });
+        setCompleted((prev) => [
+          ...prev,
+          result.success
+            ? { name, status: 'updated', diff }
+            : { name, status: 'failed', detail: result.error },
+        ]);
+      }
+
+      setCurrent(undefined);
+      setDone(true);
+    })();
+  }, []);
+
+  if (fatalError) {
+    return <StatusMessage variant="error">{fatalError}</StatusMessage>;
+  }
+
+  if (total === 0 && done) {
+    return <StatusMessage variant="info">No git settings to update.</StatusMessage>;
+  }
+
+  const updated = completed.filter((c) => c.status === 'updated' || c.status === 'installed').length;
+  const upToDate = completed.filter((c) => c.status === 'up-to-date').length;
+  const failures = completed.filter((c) => c.status === 'failed').length;
+
+  return (
+    <Box flexDirection="column">
+      {total > 0 && (
+        <StatusMessage variant="info">
+          Checking {total} git settings package(s)… (userSettings are skipped)
+        </StatusMessage>
+      )}
+      <Static items={completed}>
+        {(item) => (
+          <Box key={item.name} flexDirection="column">
+            <StatusMessage variant={item.status === 'failed' ? 'error' : 'success'}>
+              {item.name}
+              {item.status === 'up-to-date' && <Text dimColor> up to date</Text>}
+              {item.detail && ` ${item.detail}`}
+            </StatusMessage>
+            {item.diff && <DiffView diff={item.diff} />}
+          </Box>
+        )}
+      </Static>
+      {current && <Spinner label={current} />}
+      {done && (
+        <Box flexDirection="column" marginTop={1}>
+          {failures > 0 && <StatusMessage variant="error">{failures} settings package(s) failed.</StatusMessage>}
+          {updated > 0 && <StatusMessage variant="success">{updated} settings package(s) updated.</StatusMessage>}
+          {upToDate > 0 && <StatusMessage variant="info">{upToDate} settings package(s) already up to date.</StatusMessage>}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export async function settingsUpdateCommand(options: SettingsUpdateOptions = {}) {
+  const { waitUntilExit } = render(<SettingsUpdateApp options={options} />);
+  await waitUntilExit();
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,11 @@ import { removeCommand } from './commands/remove.tsx';
 import { listCommand } from './commands/list.tsx';
 import { updateCommand } from './commands/update.tsx';
 import { defaultsCommand } from './commands/defaults.tsx';
+import { settingsAddCommand } from './commands/settings-add.tsx';
+import { settingsInstallCommand } from './commands/settings-install.tsx';
+import { settingsRemoveCommand } from './commands/settings-remove.tsx';
+import { settingsListCommand } from './commands/settings-list.tsx';
+import { settingsUpdateCommand } from './commands/settings-update.tsx';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -89,6 +94,51 @@ program
   .command('defaults')
   .description('View and update default agent preferences')
   .action(defaultsCommand);
+
+// ---------------------------------------------------------------------------
+// Settings subcommand group
+// ---------------------------------------------------------------------------
+
+const settings = program
+  .command('settings')
+  .description('Manage settings packages for AI agents');
+
+settings
+  .command('add <source>')
+  .description('Add a settings package from a git or local source')
+  .option('-g, --global', 'Install globally')
+  .option('--user', 'Add as a userSettings entry (local, never auto-updated)')
+  .option('--path <path>', 'Custom installation path')
+  .option('-s, --ssh', 'Use SSH for cloning (default: HTTPS with auto-retry on auth failure)')
+  .option('--settings <names...>', 'Install specific settings package(s) by name, skipping the selection prompt')
+  .option('--strategy <strategy>', 'Apply strategy: copy, merge, or replace')
+  .action(settingsAddCommand);
+
+settings
+  .command('install')
+  .description('Install all settings packages from settings.json')
+  .option('-g, --global', 'Install globally (~/) instead of project-local')
+  .option('-s, --ssh', 'Use SSH for cloning (default: HTTPS with auto-retry on auth failure)')
+  .action(settingsInstallCommand);
+
+settings
+  .command('remove <names...>')
+  .description('Remove one or more settings packages by name')
+  .option('-g, --global', 'Remove from global (~/) directories instead of project-local')
+  .action(settingsRemoveCommand);
+
+settings
+  .command('list')
+  .description('List all settings packages in the current manifest')
+  .option('-g, --global', 'List settings from the global manifest instead of project-local')
+  .action(settingsListCommand);
+
+settings
+  .command('update')
+  .description('Re-install git settings at their manifest refs (skips userSettings)')
+  .option('-g, --global', 'Update in global (~/) directories instead of project-local')
+  .option('-s, --ssh', 'Use SSH for cloning (default: HTTPS with auto-retry on auth failure)')
+  .action(settingsUpdateCommand);
 
 program.parseAsync().catch((err) => {
   console.error(pc.red('\u2717'), err instanceof Error ? err.message : String(err));

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -28,6 +28,14 @@ interface AgentEntry {
   skillsDir: string;
   /** Absolute path where global skills live (undefined = global not supported). */
   globalSkillsDir: string | undefined;
+  /** Relative path from cwd for project-local settings (copy mode). */
+  settingsDir: string;
+  /** Absolute path where global settings live (copy mode). */
+  globalSettingsDir: string | undefined;
+  /** Absolute path to the agent's settings file (merge/replace mode). */
+  settingsFile?: string;
+  /** Absolute path to the agent's global settings file (merge/replace mode). */
+  globalSettingsFile?: string;
   /** Returns true when the agent appears to be installed on this machine. */
   detectInstalled: () => boolean;
 }
@@ -41,156 +49,210 @@ export const AGENT_REGISTRY: AgentEntry[] = [
     slug: 'claude',
     skillsDir: '.claude/skills',
     globalSkillsDir: join(claudeHome, 'skills'),
+    settingsDir: '.claude/settings',
+    globalSettingsDir: join(claudeHome, 'settings'),
+    settingsFile: join('.claude', 'settings.json'),
+    globalSettingsFile: join(claudeHome, 'settings.json'),
     detectInstalled: () => existsSync(claudeHome),
   },
   {
     slug: 'cursor',
     skillsDir: '.cursor/skills',
     globalSkillsDir: join(home, '.cursor', 'skills'),
+    settingsDir: '.cursor/settings',
+    globalSettingsDir: join(home, '.cursor', 'settings'),
     detectInstalled: () => existsSync(join(home, '.cursor')),
   },
   {
     slug: 'windsurf',
     skillsDir: '.windsurf/skills',
     globalSkillsDir: join(home, '.codeium', 'windsurf', 'skills'),
+    settingsDir: '.windsurf/settings',
+    globalSettingsDir: join(home, '.codeium', 'windsurf', 'settings'),
     detectInstalled: () => existsSync(join(home, '.codeium', 'windsurf')),
   },
   {
     slug: 'continue',
     skillsDir: '.continue/skills',
     globalSkillsDir: join(home, '.continue', 'skills'),
+    settingsDir: '.continue/settings',
+    globalSettingsDir: join(home, '.continue', 'settings'),
     detectInstalled: () => existsSync(join(home, '.continue')),
   },
   {
     slug: 'copilot',
     skillsDir: '.copilot/skills',
     globalSkillsDir: join(home, '.copilot', 'skills'),
+    settingsDir: '.copilot/settings',
+    globalSettingsDir: join(home, '.copilot', 'settings'),
     detectInstalled: () => existsSync(join(home, '.copilot')),
   },
   {
     slug: 'gemini',
     skillsDir: '.gemini/skills',
     globalSkillsDir: join(home, '.gemini', 'skills'),
+    settingsDir: '.gemini/settings',
+    globalSettingsDir: join(home, '.gemini', 'settings'),
     detectInstalled: () => existsSync(join(home, '.gemini')),
   },
   {
     slug: 'augment',
     skillsDir: '.augment/rules',
     globalSkillsDir: join(home, '.augment', 'rules'),
+    settingsDir: '.augment/settings',
+    globalSettingsDir: join(home, '.augment', 'settings'),
     detectInstalled: () => existsSync(join(home, '.augment')),
   },
   {
     slug: 'cline',
     skillsDir: '.cline/skills',
     globalSkillsDir: join(home, '.cline', 'skills'),
+    settingsDir: '.cline/settings',
+    globalSettingsDir: join(home, '.cline', 'settings'),
     detectInstalled: () => existsSync(join(home, '.cline')),
   },
   {
     slug: 'goose',
     skillsDir: '.goose/skills',
     globalSkillsDir: join(configHome, 'goose', 'skills'),
+    settingsDir: '.goose/settings',
+    globalSettingsDir: join(configHome, 'goose', 'settings'),
     detectInstalled: () => existsSync(join(configHome, 'goose')),
   },
   {
     slug: 'junie',
     skillsDir: '.junie/skills',
     globalSkillsDir: join(home, '.junie', 'skills'),
+    settingsDir: '.junie/settings',
+    globalSettingsDir: join(home, '.junie', 'settings'),
     detectInstalled: () => existsSync(join(home, '.junie')),
   },
   {
     slug: 'kiro',
     skillsDir: '.kiro/skills',
     globalSkillsDir: join(home, '.kiro', 'skills'),
+    settingsDir: '.kiro/settings',
+    globalSettingsDir: join(home, '.kiro', 'settings'),
     detectInstalled: () => existsSync(join(home, '.kiro')),
   },
   {
     slug: 'opencode',
     skillsDir: '.opencode/skills',
     globalSkillsDir: join(configHome, 'opencode', 'skills'),
+    settingsDir: '.opencode/settings',
+    globalSettingsDir: join(configHome, 'opencode', 'settings'),
     detectInstalled: () => existsSync(join(configHome, 'opencode')),
   },
   {
     slug: 'openhands',
     skillsDir: '.openhands/skills',
     globalSkillsDir: join(home, '.openhands', 'skills'),
+    settingsDir: '.openhands/settings',
+    globalSettingsDir: join(home, '.openhands', 'settings'),
     detectInstalled: () => existsSync(join(home, '.openhands')),
   },
   {
     slug: 'roo',
     skillsDir: '.roo/skills',
     globalSkillsDir: join(home, '.roo', 'skills'),
+    settingsDir: '.roo/settings',
+    globalSettingsDir: join(home, '.roo', 'settings'),
     detectInstalled: () => existsSync(join(home, '.roo')),
   },
   {
     slug: 'trae',
     skillsDir: '.trae/skills',
     globalSkillsDir: join(home, '.trae', 'skills'),
+    settingsDir: '.trae/settings',
+    globalSettingsDir: join(home, '.trae', 'settings'),
     detectInstalled: () => existsSync(join(home, '.trae')),
   },
   {
     slug: 'kode',
     skillsDir: '.kode/skills',
     globalSkillsDir: join(home, '.kode', 'skills'),
+    settingsDir: '.kode/settings',
+    globalSettingsDir: join(home, '.kode', 'settings'),
     detectInstalled: () => existsSync(join(home, '.kode')),
   },
   {
     slug: 'qwen-code',
     skillsDir: '.qwen/skills',
     globalSkillsDir: join(home, '.qwen', 'skills'),
+    settingsDir: '.qwen/settings',
+    globalSettingsDir: join(home, '.qwen', 'settings'),
     detectInstalled: () => existsSync(join(home, '.qwen')),
   },
   {
     slug: 'codex',
     skillsDir: '.codex/skills',
     globalSkillsDir: join(codexHome, 'skills'),
+    settingsDir: '.codex/settings',
+    globalSettingsDir: join(codexHome, 'settings'),
     detectInstalled: () => existsSync(codexHome) || existsSync('/etc/codex'),
   },
   {
     slug: 'amp',
     skillsDir: '.agents/skills',
     globalSkillsDir: join(configHome, 'agents', 'skills'),
+    settingsDir: '.agents/settings',
+    globalSettingsDir: join(configHome, 'agents', 'settings'),
     detectInstalled: () => existsSync(join(configHome, 'agents')),
   },
   {
     slug: 'kilo',
     skillsDir: '.kilocode/skills',
     globalSkillsDir: join(home, '.kilocode', 'skills'),
+    settingsDir: '.kilocode/settings',
+    globalSettingsDir: join(home, '.kilocode', 'settings'),
     detectInstalled: () => existsSync(join(home, '.kilocode')),
   },
   {
     slug: 'pochi',
     skillsDir: '.pochi/skills',
     globalSkillsDir: join(home, '.pochi', 'skills'),
+    settingsDir: '.pochi/settings',
+    globalSettingsDir: join(home, '.pochi', 'settings'),
     detectInstalled: () => existsSync(join(home, '.pochi')),
   },
   {
     slug: 'neovate',
     skillsDir: '.neovate/skills',
     globalSkillsDir: join(home, '.neovate', 'skills'),
+    settingsDir: '.neovate/settings',
+    globalSettingsDir: join(home, '.neovate', 'settings'),
     detectInstalled: () => existsSync(join(home, '.neovate')),
   },
   {
     slug: 'mux',
     skillsDir: '.mux/skills',
     globalSkillsDir: join(home, '.mux', 'skills'),
+    settingsDir: '.mux/settings',
+    globalSettingsDir: join(home, '.mux', 'settings'),
     detectInstalled: () => existsSync(join(home, '.mux')),
   },
   {
     slug: 'zencoder',
     skillsDir: '.zencoder/skills',
     globalSkillsDir: join(home, '.zencoder', 'skills'),
+    settingsDir: '.zencoder/settings',
+    globalSettingsDir: join(home, '.zencoder', 'settings'),
     detectInstalled: () => existsSync(join(home, '.zencoder')),
   },
   {
     slug: 'adal',
     skillsDir: '.adal/skills',
     globalSkillsDir: join(home, '.adal', 'skills'),
+    settingsDir: '.adal/settings',
+    globalSettingsDir: join(home, '.adal', 'settings'),
     detectInstalled: () => existsSync(join(home, '.adal')),
   },
   {
     slug: 'openclaw',
     skillsDir: '.openclaw/skills',
     globalSkillsDir: join(home, '.openclaw', 'skills'),
+    settingsDir: '.openclaw/settings',
+    globalSettingsDir: join(home, '.openclaw', 'settings'),
     detectInstalled: () => existsSync(join(home, '.openclaw')),
   },
 ];
@@ -276,6 +338,52 @@ export function getAgentSkillDirs(
     }
   }
   return dirs;
+}
+
+/**
+ * Given a list of agent slugs, return the settings directories for each one.
+ * Mirrors getAgentSkillDirs but uses settingsDir / globalSettingsDir.
+ */
+export function getAgentSettingsDirs(
+  agents: string[],
+  global: boolean = false,
+  cwd: string = process.cwd(),
+  customPath?: string
+): string[] {
+  if (customPath) return [customPath];
+
+  const dirs: string[] = [];
+  for (const slug of agents) {
+    const entry = AGENT_MAP.get(slug);
+    if (global) {
+      if (entry?.globalSettingsDir) dirs.push(entry.globalSettingsDir);
+    } else {
+      dirs.push(join(cwd, entry?.settingsDir ?? `.${slug}/settings`));
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Return agent slugs paired with their settings file paths for merge-capable agents.
+ * Only includes agents that have a settingsFile / globalSettingsFile defined.
+ */
+export function getAgentSettingsFiles(
+  agents: string[],
+  global: boolean = false,
+  cwd: string = process.cwd(),
+): { slug: string; filePath: string }[] {
+  const result: { slug: string; filePath: string }[] = [];
+  for (const slug of agents) {
+    const entry = AGENT_MAP.get(slug);
+    if (!entry) continue;
+    if (global) {
+      if (entry.globalSettingsFile) result.push({ slug, filePath: entry.globalSettingsFile });
+    } else {
+      if (entry.settingsFile) result.push({ slug, filePath: join(cwd, entry.settingsFile) });
+    }
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/settings-discover.ts
+++ b/src/core/settings-discover.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import matter from 'gray-matter';
+import type { SettingsPackage } from '../types/index.ts';
+
+const SETTINGS_FILENAME = 'SETTINGS.md';
+const MAX_DEPTH = 3;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Find all settings packages under rootPath (optionally narrowed to a subpath).
+ * Each settings package is the directory that contains a SETTINGS.md file.
+ */
+export async function discoverSettings(rootPath: string, subpath?: string): Promise<SettingsPackage[]> {
+  const searchPath = subpath ? join(rootPath, subpath) : rootPath;
+  const settingsFiles = await findSettingsFiles(searchPath);
+
+  const packages: SettingsPackage[] = [];
+  for (const file of settingsFiles) {
+    const pkg = await parseSettingsFile(file);
+    if (pkg) packages.push(pkg);
+  }
+  return packages;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively find all SETTINGS.md files up to MAX_DEPTH.
+ * Skips directories starting with '.' or '_'.
+ */
+async function findSettingsFiles(dirPath: string, depth: number = 0): Promise<string[]> {
+  if (depth > MAX_DEPTH) return [];
+
+  let entries;
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name.startsWith('_')) continue;
+
+    const fullPath = join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...(await findSettingsFiles(fullPath, depth + 1)));
+    } else if (entry.name.toLowerCase() === SETTINGS_FILENAME.toLowerCase()) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a SETTINGS.md file into a SettingsPackage object.
+ * Returns null if the required frontmatter fields (name, description) are missing.
+ */
+async function parseSettingsFile(filePath: string): Promise<SettingsPackage | null> {
+  const content = await readFile(filePath, 'utf-8');
+
+  let data: Record<string, unknown>;
+  try {
+    const result = matter(content);
+    data = result.data as Record<string, unknown>;
+  } catch {
+    data = extractFrontmatterFields(content);
+  }
+
+  if (!data.name || !data.description) {
+    const fallbackData = extractFrontmatterFields(content);
+    if (fallbackData.name && fallbackData.description) {
+      data = fallbackData;
+    }
+  }
+
+  if (!data.name || !data.description) return null;
+
+  return {
+    name: String(data.name),
+    description: String(data.description),
+    path: dirname(filePath),
+    metadata: data,
+  };
+}
+
+/** Extract name and description via regex when gray-matter can't parse the YAML. */
+function extractFrontmatterFields(content: string): Record<string, unknown> {
+  const block = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!block) return {};
+
+  const result: Record<string, unknown> = {};
+  const nameMatch = block[1]?.match(/^name:\s*(.+)$/m);
+  const descMatch = block[1]?.match(/^description:\s*(.+)$/m);
+  const strategyMatch = block[1]?.match(/^strategy:\s*(.+)$/m);
+  if (nameMatch) result.name = nameMatch[1]?.trim();
+  if (descMatch) result.description = descMatch[1]?.trim();
+  if (strategyMatch) result.strategy = strategyMatch[1]?.trim();
+  return result;
+}

--- a/src/core/settings-installer.ts
+++ b/src/core/settings-installer.ts
@@ -1,0 +1,296 @@
+import { mkdir, rm, cp, readFile, writeFile, readdir } from 'node:fs/promises';
+import { resolve, join, relative } from 'node:path';
+import type { SkillSource, InstallOptions, SettingsInstallResult, SettingsStrategy } from '../types/index.ts';
+import { readConfig, getAgentSettingsDirs, getAgentSettingsFiles } from './config.ts';
+import { cloneRepo, cleanupTempDir } from './git.ts';
+import { discoverSettings } from './settings-discover.ts';
+import { exists, hashDirectory, diffHashes } from '../utils/fs.ts';
+import { deepMerge } from '../utils/merge.ts';
+
+// ---------------------------------------------------------------------------
+// Git settings installation
+// ---------------------------------------------------------------------------
+
+export interface SettingsInstallOptions extends InstallOptions {
+  strategy?: SettingsStrategy;
+}
+
+export async function installGitSettings(
+  source: SkillSource,
+  settingsName: string,
+  options: SettingsInstallOptions = {}
+): Promise<SettingsInstallResult> {
+  const strategy = options.strategy ?? 'copy';
+
+  let tempDir: string | undefined;
+  try {
+    tempDir = await cloneRepo(source.url, source.ref, { ssh: options.ssh });
+
+    const packages = await discoverSettings(tempDir, source.subpath);
+
+    let pkg = packages.find((s) => s.name === settingsName);
+    if (!pkg && packages.length === 1) {
+      pkg = packages[0];
+    }
+
+    if (!pkg) {
+      const found = packages.map((s) => `"${s.name}"`).join(', ');
+      throw new Error(
+        `Settings "${settingsName}" not found in ${source.url}${source.subpath ? `/${source.subpath}` : ''}. ` +
+          (found ? `Found: ${found}` : 'No SETTINGS.md files discovered.')
+      );
+    }
+
+    // Resolve strategy: CLI flag > SETTINGS.md frontmatter > default "copy"
+    const effectiveStrategy = options.strategy
+      ?? (pkg.metadata?.strategy as SettingsStrategy | undefined)
+      ?? 'copy';
+
+    const installedPaths = await applySettings(pkg.path, settingsName, effectiveStrategy, options);
+
+    return { success: true, settings: settingsName, paths: installedPaths, strategy: effectiveStrategy };
+  } catch (error) {
+    return {
+      success: false,
+      settings: settingsName,
+      paths: [],
+      strategy,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    if (tempDir) await cleanupTempDir(tempDir).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery-only (no install) — used by `settings add` to let the user pick
+// ---------------------------------------------------------------------------
+
+export async function discoverSettingsFromSource(
+  source: SkillSource,
+  options: { ssh?: boolean } = {}
+): Promise<{ name: string; description: string; repoPath: string; strategy?: string }[]> {
+  const tempDir = await cloneRepo(source.url, source.ref, { ssh: options.ssh });
+  try {
+    const packages = await discoverSettings(tempDir, source.subpath);
+    return packages.map((s) => ({
+      name: s.name,
+      description: s.description,
+      repoPath: relative(tempDir, s.path),
+      strategy: s.metadata?.strategy as string | undefined,
+    }));
+  } finally {
+    await cleanupTempDir(tempDir).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Update check
+// ---------------------------------------------------------------------------
+
+export interface SettingsDiff {
+  added: string[];
+  removed: string[];
+  changed: string[];
+  upToDate: boolean;
+}
+
+export async function checkSettingsForUpdates(
+  source: SkillSource,
+  settingsName: string,
+  options: SettingsInstallOptions = {}
+): Promise<SettingsDiff | null> {
+  const installDirs = await resolveInstallDirs(options);
+  const localPath = join(installDirs[0]!, settingsName);
+
+  if (!(await exists(localPath))) return null;
+
+  let tempDir: string | undefined;
+  try {
+    tempDir = await cloneRepo(source.url, source.ref, { ssh: options.ssh });
+
+    const packages = await discoverSettings(tempDir, source.subpath);
+    let pkg = packages.find((s) => s.name === settingsName);
+    if (!pkg && packages.length === 1) pkg = packages[0];
+    if (!pkg) return null;
+
+    const [remoteHashes, localHashes] = await Promise.all([
+      hashDirectory(pkg.path),
+      hashDirectory(localPath),
+    ]);
+
+    const diff = diffHashes(localHashes, remoteHashes);
+    return { ...diff, upToDate: diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0 };
+  } finally {
+    if (tempDir) await cleanupTempDir(tempDir).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// User settings installation
+// ---------------------------------------------------------------------------
+
+export async function installUserSettings(
+  source: SkillSource,
+  settingsName: string,
+  options: SettingsInstallOptions = {}
+): Promise<SettingsInstallResult> {
+  const strategy = options.strategy ?? 'copy';
+  const sourcePath = resolve(source.url);
+
+  if (!(await exists(sourcePath))) {
+    return {
+      success: false,
+      settings: settingsName,
+      paths: [],
+      strategy,
+      error: `User settings path not found: ${sourcePath}`,
+    };
+  }
+
+  try {
+    // Discover to get strategy from SETTINGS.md if not overridden
+    const packages = await discoverSettings(sourcePath);
+    const pkg = packages.length > 0 ? packages[0] : undefined;
+    const effectiveStrategy = options.strategy
+      ?? (pkg?.metadata?.strategy as SettingsStrategy | undefined)
+      ?? 'copy';
+
+    const installedPaths = await applySettings(sourcePath, settingsName, effectiveStrategy, options);
+    return { success: true, settings: settingsName, paths: installedPaths, strategy: effectiveStrategy };
+  } catch (error) {
+    return {
+      success: false,
+      settings: settingsName,
+      paths: [],
+      strategy,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core apply logic
+// ---------------------------------------------------------------------------
+
+async function applySettings(
+  sourcePath: string,
+  settingsName: string,
+  strategy: SettingsStrategy,
+  options: SettingsInstallOptions
+): Promise<string[]> {
+  if (strategy === 'copy') {
+    const installDirs = await resolveInstallDirs(options);
+    return copyToAll(sourcePath, settingsName, installDirs);
+  }
+
+  // merge or replace — apply to agent settings files
+  const config = await getEffectiveConfig(options.global ?? false);
+  const agents =
+    options.agents ??
+    (config.agents.length > 0 ? config.agents : config.global?.defaultAgents ?? ['claude']);
+
+  const agentFiles = getAgentSettingsFiles(agents, options.global);
+  if (agentFiles.length === 0) {
+    // Fallback to copy mode if no agents support file-based settings
+    const installDirs = await resolveInstallDirs(options);
+    return copyToAll(sourcePath, settingsName, installDirs);
+  }
+
+  // Find JSON files in the settings package to merge/replace with
+  const jsonFiles = await findJsonFiles(sourcePath);
+  const paths: string[] = [];
+
+  for (const { filePath: agentFile } of agentFiles) {
+    for (const jsonFile of jsonFiles) {
+      const sourceContent = await readFile(jsonFile, 'utf-8');
+      let sourceData: Record<string, unknown>;
+      try {
+        sourceData = JSON.parse(sourceContent);
+      } catch {
+        continue; // skip non-JSON files
+      }
+
+      if (strategy === 'replace') {
+        await mkdir(join(agentFile, '..'), { recursive: true });
+        await writeFile(agentFile, JSON.stringify(sourceData, null, 2) + '\n', 'utf-8');
+      } else {
+        // merge
+        let existing: Record<string, unknown> = {};
+        if (await exists(agentFile)) {
+          try {
+            existing = JSON.parse(await readFile(agentFile, 'utf-8'));
+          } catch {
+            existing = {};
+          }
+        }
+        const merged = deepMerge(existing, sourceData);
+        await mkdir(join(agentFile, '..'), { recursive: true });
+        await writeFile(agentFile, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+      }
+      paths.push(agentFile);
+    }
+  }
+
+  return paths;
+}
+
+async function findJsonFiles(dirPath: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'SETTINGS.md') continue;
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function resolveInstallDirs(options: SettingsInstallOptions): Promise<string[]> {
+  if (options.customPath) return [options.customPath];
+
+  const config = await getEffectiveConfig(options.global ?? false);
+  const agents =
+    options.agents ??
+    (config.agents.length > 0 ? config.agents : config.global?.defaultAgents ?? ['claude']);
+
+  return getAgentSettingsDirs(agents, options.global, process.cwd());
+}
+
+async function copyToAll(sourcePath: string, settingsName: string, installDirs: string[]): Promise<string[]> {
+  const paths: string[] = [];
+  for (const dir of installDirs) {
+    const targetPath = join(dir, settingsName);
+    await mkdir(dir, { recursive: true });
+    await rm(targetPath, { recursive: true, force: true });
+    await cp(sourcePath, targetPath, { recursive: true });
+    paths.push(targetPath);
+  }
+  return paths;
+}
+
+async function getEffectiveConfig(global: boolean) {
+  const { readConfig } = await import('./config.ts');
+  if (global) {
+    const g = await readConfig(process.cwd(), true);
+    return g ?? { version: 1, agents: ['claude'] };
+  }
+
+  const project = await readConfig();
+  if (project) return project;
+
+  const g = await readConfig(process.cwd(), true);
+  return g ?? { version: 1, agents: ['claude'] };
+}

--- a/src/core/settings-manifest.ts
+++ b/src/core/settings-manifest.ts
@@ -1,0 +1,164 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import type { SettingsManifest, SettingsEntry, SettingsStrategy } from '../types/index.ts';
+import { exists } from '../utils/fs.ts';
+import { parseSource } from './source-parser.ts';
+
+const MANIFEST_FILENAME = 'settings.json';
+
+// ---------------------------------------------------------------------------
+// Helper to extract source, path, and strategy from SettingsEntry
+// ---------------------------------------------------------------------------
+
+export function parseSettingsEntry(entry: SettingsEntry): {
+  source: string;
+  customPath?: string;
+  strategy?: SettingsStrategy;
+} {
+  return { source: entry.source, customPath: entry.path, strategy: entry.strategy };
+}
+
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+
+export async function readSettingsManifest(cwd: string = process.cwd()): Promise<SettingsManifest | null> {
+  const manifestPath = join(cwd, MANIFEST_FILENAME);
+  if (!(await exists(manifestPath))) return null;
+
+  const raw = await readFile(manifestPath, 'utf-8');
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Invalid JSON in ${manifestPath}: ${e instanceof Error ? e.message : e}`);
+  }
+  validateSettingsManifest(manifest);
+  return manifest;
+}
+
+export async function writeSettingsManifest(manifest: SettingsManifest, cwd: string = process.cwd()): Promise<void> {
+  await mkdir(cwd, { recursive: true });
+  const manifestPath = join(cwd, MANIFEST_FILENAME);
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Mutation helpers
+// ---------------------------------------------------------------------------
+
+export async function addSettingsToManifest(
+  settingsName: string,
+  source: string,
+  options: { cwd?: string; isUserSettings?: boolean; customPath?: string; strategy?: SettingsStrategy } = {}
+): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  let manifest = await readSettingsManifest(cwd);
+
+  if (!manifest) {
+    manifest = {
+      name: basename(cwd),
+      version: '1.0.0',
+      settings: {},
+    };
+  }
+
+  const entry: SettingsEntry = {
+    source,
+    ...(options.customPath && { path: options.customPath }),
+    ...(options.strategy && { strategy: options.strategy }),
+  };
+
+  if (options.isUserSettings) {
+    if (!manifest.userSettings) manifest.userSettings = {};
+    manifest.userSettings[settingsName] = entry;
+  } else {
+    manifest.settings[settingsName] = entry;
+  }
+
+  await writeSettingsManifest(manifest, cwd);
+}
+
+export async function removeSettingsFromManifest(settingsName: string, cwd: string = process.cwd()): Promise<boolean> {
+  const manifest = await readSettingsManifest(cwd);
+  if (!manifest) return false;
+
+  let removed = false;
+
+  if (manifest.settings[settingsName]) {
+    delete manifest.settings[settingsName];
+    removed = true;
+  }
+  if (manifest.userSettings?.[settingsName]) {
+    delete manifest.userSettings[settingsName];
+    removed = true;
+  }
+
+  if (removed) await writeSettingsManifest(manifest, cwd);
+  return removed;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const VALID_STRATEGIES: SettingsStrategy[] = ['copy', 'merge', 'replace'];
+
+function validateSettingsManifest(manifest: unknown): asserts manifest is SettingsManifest {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('Invalid settings.json: must be a JSON object');
+  }
+
+  const m = manifest as Record<string, unknown>;
+
+  if (typeof m.name !== 'string') {
+    throw new Error('Invalid settings.json: "name" must be a string');
+  }
+  if (typeof m.version !== 'string') {
+    throw new Error('Invalid settings.json: "version" must be a string');
+  }
+  if (!m.settings || typeof m.settings !== 'object' || Array.isArray(m.settings)) {
+    throw new Error('Invalid settings.json: "settings" must be an object');
+  }
+
+  for (const [name, entry] of Object.entries(m.settings as Record<string, unknown>)) {
+    validateSettingsEntry(entry, name, false);
+  }
+
+  if (m.userSettings !== undefined) {
+    if (typeof m.userSettings !== 'object' || Array.isArray(m.userSettings)) {
+      throw new Error('Invalid settings.json: "userSettings" must be an object');
+    }
+    for (const [name, entry] of Object.entries(m.userSettings as Record<string, unknown>)) {
+      validateSettingsEntry(entry, name, true);
+    }
+  }
+}
+
+function validateSettingsEntry(entry: unknown, name: string, isUserSettings: boolean): asserts entry is SettingsEntry {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(`Invalid settings.json: ${isUserSettings ? 'userSettings' : 'settings'} "${name}" must be an object`);
+  }
+
+  const e = entry as Record<string, unknown>;
+
+  if (typeof e.source !== 'string') {
+    throw new Error(`Invalid settings.json: ${isUserSettings ? 'userSettings' : 'settings'} "${name}" must have a "source" string`);
+  }
+
+  if (e.path !== undefined && typeof e.path !== 'string') {
+    throw new Error(`Invalid settings.json: ${isUserSettings ? 'userSettings' : 'settings'} "${name}" path must be a string if provided`);
+  }
+
+  if (e.strategy !== undefined) {
+    if (typeof e.strategy !== 'string' || !VALID_STRATEGIES.includes(e.strategy as SettingsStrategy)) {
+      throw new Error(`Invalid settings.json: ${isUserSettings ? 'userSettings' : 'settings'} "${name}" strategy must be one of: ${VALID_STRATEGIES.join(', ')}`);
+    }
+  }
+
+  const parsed = parseSource(e.source);
+
+  if (isUserSettings && parsed.type !== 'file') {
+    throw new Error(`Invalid settings.json: userSettings "${name}" must use the file: prefix`);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,3 +81,54 @@ export interface InstallResult {
   paths: string[];
   error?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Settings types
+// ---------------------------------------------------------------------------
+
+/** How a settings package is applied to an agent. */
+export type SettingsStrategy = 'copy' | 'merge' | 'replace';
+
+/**
+ * A discovered settings package parsed from a SETTINGS.md file.
+ */
+export interface SettingsPackage {
+  name: string;
+  description: string;
+  /** Absolute path to the directory containing SETTINGS.md */
+  path: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Settings entry in manifest with source, optional custom path, and strategy.
+ */
+export interface SettingsEntry {
+  source: string;
+  path?: string;
+  strategy?: SettingsStrategy;
+}
+
+/**
+ * The settings.json manifest — the declarative list of settings packages for a project.
+ */
+export interface SettingsManifest {
+  name: string;
+  version: string;
+  /** Git-based settings, updated by `konstruct settings update` */
+  settings: Record<string, SettingsEntry>;
+  /** Local user-created settings, never auto-updated */
+  userSettings?: Record<string, SettingsEntry>;
+}
+
+/**
+ * Result of a single settings installation.
+ */
+export interface SettingsInstallResult {
+  success: boolean;
+  settings: string;
+  /** All paths the settings were applied to (one per agent) */
+  paths: string[];
+  strategy: SettingsStrategy;
+  error?: string;
+}

--- a/src/utils/merge.ts
+++ b/src/utils/merge.ts
@@ -1,0 +1,47 @@
+/**
+ * Deep-merge two JSON-like values. Used to merge settings packages into
+ * agent settings files.
+ *
+ * Rules:
+ *   - Arrays: concatenate and deduplicate (primitive items only)
+ *   - Objects: recursive merge; source keys win for scalars
+ *   - Scalars: source wins
+ */
+export function deepMerge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T {
+  const result = { ...target };
+
+  for (const key of Object.keys(source) as (keyof T)[]) {
+    const srcVal = source[key];
+    const tgtVal = result[key];
+
+    if (srcVal === undefined) continue;
+
+    if (Array.isArray(srcVal) && Array.isArray(tgtVal)) {
+      // Concatenate and deduplicate (works for primitives; objects kept as-is)
+      const merged = [...tgtVal, ...srcVal];
+      const seen = new Set<unknown>();
+      const deduped: unknown[] = [];
+      for (const item of merged) {
+        const key = typeof item === 'object' && item !== null ? JSON.stringify(item) : item;
+        if (!seen.has(key)) {
+          seen.add(key);
+          deduped.push(item);
+        }
+      }
+      (result as Record<string, unknown>)[key as string] = deduped;
+    } else if (isPlainObject(srcVal) && isPlainObject(tgtVal)) {
+      (result as Record<string, unknown>)[key as string] = deepMerge(
+        tgtVal as Record<string, unknown>,
+        srcVal as Record<string, unknown>,
+      );
+    } else {
+      (result as Record<string, unknown>)[key as string] = srcVal;
+    }
+  }
+
+  return result;
+}
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null && !Array.isArray(val);
+}


### PR DESCRIPTION
## Summary

Implements a complete parallel system for **settings packages** alongside the existing skills system. Settings packages can be sourced from git repos, discovered via `SETTINGS.md` frontmatter, and installed/updated/removed across all 26 registered AI agents.

### What's new

- **New CLI command group**: `konstruct settings` with `add`, `install`, `remove`, `list`, and `update` subcommands — mirroring the existing skill commands
- **Three apply strategies**: `copy` (default, like skills), `merge` (deep-merges JSON into agent settings files), and `replace` (overwrites agent settings files)
- **SETTINGS.md discovery**: Settings packages are discovered by `SETTINGS.md` files with YAML frontmatter (`name`, `description`, optional `strategy`)
- **settings.json manifest**: Parallel to `skills.json` — tracks installed settings packages with source, path, and strategy
- **Agent registry extended**: All 26 agents now have `settingsDir`/`globalSettingsDir` for copy mode; Claude additionally has `settingsFile`/`globalSettingsFile` for merge/replace mode
- **Deep merge utility**: `src/utils/merge.ts` — arrays are concatenated and deduplicated, objects are recursively merged, source wins for scalars
- **Init updated**: `konstruct init` now creates both `skills.json` and `settings.json`

### New files

| File | Purpose |
|------|---------|
| `src/types/index.ts` | Added `SettingsStrategy`, `SettingsPackage`, `SettingsEntry`, `SettingsManifest`, `SettingsInstallResult` |
| `src/utils/merge.ts` | Standalone `deepMerge(target, source)` utility |
| `src/core/settings-discover.ts` | `discoverSettings()` — finds `SETTINGS.md` files recursively |
| `src/core/settings-manifest.ts` | Read/write/mutate `settings.json` manifest |
| `src/core/settings-installer.ts` | Install/update/check settings with copy/merge/replace strategies |
| `src/cli/commands/settings-*.tsx` | Five CLI command components (add, install, remove, list, update) |

### Modified files

| File | Changes |
|------|---------|
| `src/core/config.ts` | Extended `AgentEntry` with settings fields; added `getAgentSettingsDirs()` and `getAgentSettingsFiles()` |
| `src/cli/utils.ts` | Updated `formatInstallTargets` regex to match `/settings/` paths and settings file paths |
| `src/cli/index.ts` | Registered `settings` subcommand group with all 5 subcommands |
| `src/cli/commands/init.tsx` | Added parallel `settings.json` creation |

### Usage

```bash
# Add a settings package (copy mode, default)
konstruct settings add github:org/my-settings

# Add with merge strategy (merges JSON into agent settings files)
konstruct settings add github:org/claude-perms --strategy merge

# Install all settings from settings.json
konstruct settings install

# List, update, remove
konstruct settings list
konstruct settings update
konstruct settings remove my-settings
```

### Known limitations (v1)

- **Merge removal**: `settings remove` for merge-mode settings removes the manifest entry and warns; it cannot auto-reverse the merge
- **Merge-capable agents**: Only Claude has `settingsFile`/`globalSettingsFile` initially; other agents fall back to copy mode
- **No merge conflict detection**: When two packages merge into the same file, last-write-wins for scalars, arrays are concatenated/deduped

## Test plan

- [x] `npx tsx src/cli/index.ts settings --help` — shows all subcommands
- [x] All 60 existing tests pass (`npm test`) — no regressions
- [ ] Create a test settings package with `SETTINGS.md` and verify `settings add`, `settings list`, `settings remove`
- [ ] Test merge mode: create a package with `strategy: merge` in frontmatter, verify it merges into agent settings